### PR TITLE
Apply multi-arch hints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Package: libtracecmd1
 Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: Library for creating and reading trace-cmd data files (shared library)
  The libtracecmd library provides APIs to read trace-cmd data files.
  .


### PR DESCRIPTION
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints).

* libtracecmd1: Add Multi-Arch: same. This fixes: libtracecmd1 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/c9c0efd3-deca-47bc-b0bd-f24dacebe03e.